### PR TITLE
Trebuchet: Never show page indicator in app drawer

### DIFF
--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -1718,6 +1718,8 @@ public class Workspace extends PagedView
         mWindowToken = getWindowToken();
         computeScroll();
         mDragController.setWindowToken(mWindowToken);
+        if (mLauncher.isAppsViewVisible() && mPageIndicator != null)
+            mPageIndicator.setVisibility(INVISIBLE);
     }
 
     protected void onDetachedFromWindow() {


### PR DESCRIPTION
When rotation is enabled and we rotate the app launcher, we attempt
to update the indicator alpha state before the view is attached. This
results in the alpha state not applying to the indicator.  Instead,
always set the view to INVISIBLE when the app drawer is showing and
the workspace is attached.

FEIJ-998
Change-Id: Ia2691a12c2cc79ea76a7e91d7d13e94b97df09b5
